### PR TITLE
Fix path to config file

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -45,7 +45,7 @@ class ServiceProvider extends IlluminateServiceProvider
     public function boot()
     {
         $this->publishes([
-            __DIR__.'/config/wuifdesign-seo.php' => config_path('seo.php'),
+            __DIR__.'/config/seo.php' => config_path('seo.php'),
         ]);
     }
 


### PR DESCRIPTION
Get Can't locate path: </home/vagrant/Code/herbax.dev/vendor/wuifdesign/laravel-seo/src/config/wuifdesign-seo.php> when doing php artisan vendor:publish ... Config file name is seo.php not wuifdesign-seo.php
